### PR TITLE
Change how classes are called

### DIFF
--- a/manifests/chronograf.pp
+++ b/manifests/chronograf.pp
@@ -25,6 +25,10 @@ class tick_stack::chronograf (
 
   include tick_stack::repo
 
+  contain tick_stack::chronograf::install
+  contain tick_stack::chronograf::config
+  contain tick_stack::chronograf::service
+
   Class['tick_stack::chronograf::install']
   -> Class['tick_stack::chronograf::config']
   ~> Class['tick_stack::chronograf::service']

--- a/manifests/chronograf.pp
+++ b/manifests/chronograf.pp
@@ -1,15 +1,20 @@
 # == Class: tick_stack::chronograf
 #
 class tick_stack::chronograf (
+  # For Install-class
   $ensure             = $tick_stack::chronograf::params::ensure,
 
+  # For Config-class
+  $conf_path          = $tick_stack::chronograf::params::conf_path,
+  $template           = $tick_stack::chronograf::params::template,
+
+  # For Service-class
   $service            = $tick_stack::chronograf::params::service,
   $enable             = $tick_stack::chronograf::params::enable,
   $hasrestart         = $tick_stack::chronograf::params::hasrestart,
   $hasstatus          = $tick_stack::chronograf::params::hasstatus,
 
-  $conf_path          = $tick_stack::chronograf::params::conf_path,
-  $template           = $tick_stack::chronograf::params::template,
+  # Specific configuration settings:
   $host               = $tick_stack::chronograf::params::host,
   $port               = $tick_stack::chronograf::params::port,
   $influxdb_url       = $tick_stack::chronograf::params::influxdb_url,
@@ -33,18 +38,4 @@ class tick_stack::chronograf (
   -> Class['tick_stack::chronograf::config']
   ~> Class['tick_stack::chronograf::service']
 
-  # class {'tick_stack::chronograf::install':
-  #   require => Class['tick_stack::repo'],
-  #   ensure  => $ensure,
-  # }
-  # -> class {'tick_stack::chronograf::config':
-  #   conf_path => $conf_path,
-  #   template  => $template,
-  # }
-  # ~> class {'tick_stack::chronograf::service':
-  #   service    => $service,
-  #   enable     => $enable,
-  #   hasrestart => $hasrestart,
-  #   hasstatus  => $hasstatus,
-  # }
 }

--- a/manifests/chronograf.pp
+++ b/manifests/chronograf.pp
@@ -22,19 +22,25 @@ class tick_stack::chronograf (
   $key                = $tick_stack::chronograf::params::key,
 
   ) inherits tick_stack::chronograf::params {
+
   include tick_stack::repo
-  class {'tick_stack::chronograf::install':
-    require => Class['tick_stack::repo'],
-    ensure  => $ensure,
-  }
-  -> class {'tick_stack::chronograf::config':
-    conf_path => $conf_path,
-    template  => $template,
-  }
-  ~> class {'tick_stack::chronograf::service':
-    service    => $service,
-    enable     => $enable,
-    hasrestart => $hasrestart,
-    hasstatus  => $hasstatus,
-  }
+
+  Class['tick_stack::chronograf::install']
+  -> Class['tick_stack::chronograf::config']
+  ~> Class['tick_stack::chronograf::service']
+
+  # class {'tick_stack::chronograf::install':
+  #   require => Class['tick_stack::repo'],
+  #   ensure  => $ensure,
+  # }
+  # -> class {'tick_stack::chronograf::config':
+  #   conf_path => $conf_path,
+  #   template  => $template,
+  # }
+  # ~> class {'tick_stack::chronograf::service':
+  #   service    => $service,
+  #   enable     => $enable,
+  #   hasrestart => $hasrestart,
+  #   hasstatus  => $hasstatus,
+  # }
 }

--- a/manifests/chronograf/config.pp
+++ b/manifests/chronograf/config.pp
@@ -1,14 +1,16 @@
 # == Class: tick_stack::chronograf::config
 #
-class tick_stack::chronograf::config (
-  $conf_path = $tick_stack::chronograf::params::conf_path,
-  $template  = $tick_stack::chronograf::params::template,
-  ) inherits tick_stack::chronograf::params {
-    file { $conf_path:
-      ensure  => present,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template($template),
-    }
+class tick_stack::chronograf::config {
+  assert_private()
+
+  $conf_path = $tick_stack::chronograf::conf_path
+  $template  = $tick_stack::chronograf::template
+
+  file { $conf_path:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template($template),
+  }
 }

--- a/manifests/chronograf/install.pp
+++ b/manifests/chronograf/install.pp
@@ -1,9 +1,11 @@
 # == Class: tick_stack::chronograf::install
 #
-class tick_stack::chronograf::install (
-  $ensure   = $tick_stack::chronograf::params::ensure,
-  ) inherits tick_stack::chronograf::params {
+class tick_stack::chronograf::install {
+  assert_private()
+
+  $ensure = $tick_stack::chronograf::ensure
+
   package { 'chronograf':
-      ensure   => $ensure,
+    ensure => $ensure,
   }
 }

--- a/manifests/chronograf/service.pp
+++ b/manifests/chronograf/service.pp
@@ -1,15 +1,17 @@
 # == Class: tick_stack::chronograf::service
 #
-class tick_stack::chronograf::service (
-  $service    = $tick_stack::chronograf::params::service,
-  $enable     = $tick_stack::chronograf::params::enable,
-  $hasrestart = $tick_stack::chronograf::params::hasrestart,
-  $hasstatus  = $tick_stack::chronograf::params::hasstatus,
-  ) inherits tick_stack::chronograf::params {
-    service { 'chronograf':
-      ensure     => $service,
-      enable     => $enable,
-      hasrestart => $hasrestart,
-      hasstatus  => $hasstatus,
-    }
+class tick_stack::chronograf::service {
+  assert_private()
+
+  $service    = $tick_stack::chronograf::service
+  $enable     = $tick_stack::chronograf::enable
+  $hasrestart = $tick_stack::chronograf::hasrestart
+  $hasstatus  = $tick_stack::chronograf::hasstatus
+
+  service { 'chronograf':
+    ensure     => $service,
+    enable     => $enable,
+    hasrestart => $hasrestart,
+    hasstatus  => $hasstatus,
+  }
 }

--- a/manifests/influxdb.pp
+++ b/manifests/influxdb.pp
@@ -51,18 +51,4 @@ class tick_stack::influxdb (
   -> Class['tick_stack::influxdb::config']
   ~> Class['tick_stack::influxdb::service']
 
-  # class {'tick_stack::influxdb::install':
-  #   require => Class['tick_stack::repo'],
-  #   ensure  => $ensure,
-  # }
-  # -> class {'tick_stack::influxdb::config':
-  #   conf_path => $conf_path,
-  #   template  => $template,
-  # }
-  # ~> class {'tick_stack::influxdb::service':
-  #   service    => $service,
-  #   enable     => $enable,
-  #   hasrestart => $hasrestart,
-  #   hasstatus  => $hasstatus,
-  # }
 }

--- a/manifests/influxdb.pp
+++ b/manifests/influxdb.pp
@@ -40,19 +40,25 @@ class tick_stack::influxdb (
   Hash $subscriber                    = $tick_stack::influxdb::params::subscriber,
   Hash $tls                           = $tick_stack::influxdb::params::tls,
   ) inherits tick_stack::influxdb::params  {
+
   include tick_stack::repo
-  class {'tick_stack::influxdb::install':
-    require => Class['tick_stack::repo'],
-    ensure  => $ensure,
-  }
-  -> class {'tick_stack::influxdb::config':
-    conf_path => $conf_path,
-    template  => $template,
-  }
-  ~> class {'tick_stack::influxdb::service':
-    service    => $service,
-    enable     => $enable,
-    hasrestart => $hasrestart,
-    hasstatus  => $hasstatus,
-  }
+
+  Class['tick_stack::influxdb::install']
+  -> Class['tick_stack::influxdb::config']
+  ~> Class['tick_stack::influxdb::service']
+
+  # class {'tick_stack::influxdb::install':
+  #   require => Class['tick_stack::repo'],
+  #   ensure  => $ensure,
+  # }
+  # -> class {'tick_stack::influxdb::config':
+  #   conf_path => $conf_path,
+  #   template  => $template,
+  # }
+  # ~> class {'tick_stack::influxdb::service':
+  #   service    => $service,
+  #   enable     => $enable,
+  #   hasrestart => $hasrestart,
+  #   hasstatus  => $hasstatus,
+  # }
 }

--- a/manifests/influxdb.pp
+++ b/manifests/influxdb.pp
@@ -43,6 +43,10 @@ class tick_stack::influxdb (
 
   include tick_stack::repo
 
+  contain tick_stack::influxdb::install
+  contain tick_stack::influxdb::config
+  contain tick_stack::influxdb::service
+
   Class['tick_stack::influxdb::install']
   -> Class['tick_stack::influxdb::config']
   ~> Class['tick_stack::influxdb::service']

--- a/manifests/influxdb/config.pp
+++ b/manifests/influxdb/config.pp
@@ -1,12 +1,16 @@
 # == Class: tick_stack::influxdb::config
 #
-class tick_stack::influxdb::config (
-  $conf_path = $tick_stack::influxdb::params::conf_path,
-  $template  = $tick_stack::influxdb::params::template,
+class tick_stack::influxdb::config {
+  assert_private()
 
-  ) inherits tick_stack::influxdb::params  {
+  $conf_path = $tick_stack::influxdb::conf_path
+  $template  = $tick_stack::influxdb::template
+
   file { $conf_path:
     ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
     content => template($template)
   }
 }

--- a/manifests/influxdb/install.pp
+++ b/manifests/influxdb/install.pp
@@ -1,8 +1,10 @@
 # == Class: tick_stack::influxdb::install
 #
-class tick_stack::influxdb::install (
-  $ensure = $tick_stack::influxdb::params::ensure
-  ) inherits tick_stack::influxdb::params {
+class tick_stack::influxdb::install {
+  assert_private()
+
+  $ensure = $tick_stack::influxdb::ensure
+
   package { 'influxdb':
     ensure => $ensure,
   }

--- a/manifests/influxdb/service.pp
+++ b/manifests/influxdb/service.pp
@@ -1,11 +1,13 @@
 # == Class: tick_stack::influxdb::service
 #
-class tick_stack::influxdb::service (
-  $service    = $tick_stack::influxdb::params::service,
-  $enable     = $tick_stack::influxdb::params::enable,
-  $hasrestart = $tick_stack::influxdb::params::hasrestart,
-  $hasstatus  = $tick_stack::influxdb::params::hasstatus,
-  ) inherits tick_stack::influxdb::params {
+class tick_stack::influxdb::service {
+  assert_private()
+  
+  $service    = $tick_stack::influxdb::service
+  $enable     = $tick_stack::influxdb::enable
+  $hasrestart = $tick_stack::influxdb::hasrestart
+  $hasstatus  = $tick_stack::influxdb::hasstatus
+
   service { 'influxdb':
     ensure     => $service,
     enable     => $enable,

--- a/manifests/kapacitor.pp
+++ b/manifests/kapacitor.pp
@@ -15,18 +15,26 @@ class tick_stack::kapacitor (
 
   include tick_stack::repo
 
-  class {'tick_stack::kapacitor::install':
-    require => Class['tick_stack::repo'],
-    ensure  => $ensure,
-  }
-  -> class {'tick_stack::kapacitor::config':
-    conf_path => $conf_path,
-    template  => $template,
-  }
-  ~> class {'tick_stack::kapacitor::service':
-    service    => $service,
-    enable     => $enable,
-    hasrestart => $hasrestart,
-    hasstatus  => $hasstatus,
-  }
+  contain tick_stack::kapacitor::install
+  contain tick_stack::kapacitor::config
+  contain tick_stack::kapacitor::service
+
+  Class['tick_stack::kapacitor::install']
+  -> Class['tick_stack::kapacitor::config']
+  ~> Class['tick_stack::kapacitor::service']
+
+  # class {'tick_stack::kapacitor::install':
+  #   require => Class['tick_stack::repo'],
+  #   ensure  => $ensure,
+  # }
+  # -> class {'tick_stack::kapacitor::config':
+  #   conf_path => $conf_path,
+  #   template  => $template,
+  # }
+  # ~> class {'tick_stack::kapacitor::service':
+  #   service    => $service,
+  #   enable     => $enable,
+  #   hasrestart => $hasrestart,
+  #   hasstatus  => $hasstatus,
+  # }
 }

--- a/manifests/kapacitor.pp
+++ b/manifests/kapacitor.pp
@@ -1,15 +1,22 @@
 # == Class: tick_stack::kapacitor
 #
 class tick_stack::kapacitor (
+  # For Install-class
   $ensure     = $tick_stack::kapacitor::params::ensure,
 
+  # For Config-class
   $conf_path  = $tick_stack::kapacitor::params::conf_path,
   $template   = $tick_stack::kapacitor::params::template,
 
+  # For Service-class
   $service    = $tick_stack::kapacitor::params::service,
   $enable     = $tick_stack::kapacitor::params::enable,
   $hasrestart = $tick_stack::kapacitor::params::hasrestart,
   $hasstatus  = $tick_stack::kapacitor::params::hasstatus,
+
+  # Specific configuration settings:
+  Hash $http       = $tick_stack::kapacitor::params::http,
+  String $data_dir = $tick_stack::kapacitor::params::data_dir,
 
   ) inherits tick_stack::kapacitor::params {
 
@@ -23,18 +30,4 @@ class tick_stack::kapacitor (
   -> Class['tick_stack::kapacitor::config']
   ~> Class['tick_stack::kapacitor::service']
 
-  # class {'tick_stack::kapacitor::install':
-  #   require => Class['tick_stack::repo'],
-  #   ensure  => $ensure,
-  # }
-  # -> class {'tick_stack::kapacitor::config':
-  #   conf_path => $conf_path,
-  #   template  => $template,
-  # }
-  # ~> class {'tick_stack::kapacitor::service':
-  #   service    => $service,
-  #   enable     => $enable,
-  #   hasrestart => $hasrestart,
-  #   hasstatus  => $hasstatus,
-  # }
 }

--- a/manifests/kapacitor/config.pp
+++ b/manifests/kapacitor/config.pp
@@ -1,11 +1,16 @@
 # == Class: tick_stack::kapacitor::config
 #
-class tick_stack::kapacitor::config(
-  $conf_path = $tick_stack::kapacitor::params::conf_path,
-  $template  = $tick_stack::kapacitor::params::template,
-  ) inherits tick_stack::kapacitor::params {
+class tick_stack::kapacitor::config {
+  assert_private()
+
+  $conf_path = $tick_stack::kapacitor::conf_path
+  $template  = $tick_stack::kapacitor::template
+
   file { $conf_path:
     ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
     content => template($template)
   }
 }

--- a/manifests/kapacitor/install.pp
+++ b/manifests/kapacitor/install.pp
@@ -1,8 +1,9 @@
 # == Class: tick_stack::kapacitor::install
 #
-class tick_stack::kapacitor::install (
-  $ensure    = $tick_stack::kapacitor::params::ensure,
-  ) inherits tick_stack::kapacitor::params {
+class tick_stack::kapacitor::install {
+  assert_private()
+
+  $ensure = $tick_stack::kapacitor::ensure
 
   package { 'kapacitor':
     ensure => $ensure,

--- a/manifests/kapacitor/service.pp
+++ b/manifests/kapacitor/service.pp
@@ -1,11 +1,13 @@
 # == Class: tick_stack::kapacitor::service
 #
-class tick_stack::kapacitor::service (
-  $service    = $tick_stack::kapacitor::params::service,
-  $enable     = $tick_stack::kapacitor::params::enable,
-  $hasrestart = $tick_stack::kapacitor::params::hasrestart,
-  $hasstatus  = $tick_stack::kapacitor::params::hasstatus,
-  ) inherits tick_stack::kapacitor::params {
+class tick_stack::kapacitor::service {
+  assert_private()
+
+  $service    = $tick_stack::kapacitor::service
+  $enable     = $tick_stack::kapacitor::enable
+  $hasrestart = $tick_stack::kapacitor::hasrestart
+  $hasstatus  = $tick_stack::kapacitor::hasstatus
+
   service { 'kapacitor':
     ensure     => $service,
     enable     => $enable,

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -22,24 +22,10 @@ class tick_stack::telegraf (
 
   contain tick_stack::telegraf::install
   contain tick_stack::telegraf::config
-  contain tick_stack::tick_stack::telegraf::service
+  contain tick_stack::telegraf::service
 
   Class['tick_stack::telegraf::install']
   -> Class['tick_stack::telegraf::config']
   ~> Class['tick_stack::telegraf::service']
 
-  # class {'tick_stack::telegraf::install':
-  #   require => Class['tick_stack::repo'],
-  #   ensure  => $ensure,
-  # }
-  # -> class {'tick_stack::telegraf::config':
-  #   conf_path => $conf_path,
-  #   template  => $template,
-  # }
-  # ~> class {'tick_stack::telegraf::service':
-  #   service    => $service,
-  #   enable     => $enable,
-  #   hasrestart => $hasrestart,
-  #   hasstatus  => $hasstatus,
-  # }
 }

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -20,7 +20,6 @@ class tick_stack::telegraf (
   Hash $outputs     = $tick_stack::telegraf::params::outputs,
   Hash $inputs      = $tick_stack::telegraf::params::inputs,
 
-
   ) inherits tick_stack::telegraf::params {
 
   include tick_stack::repo

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -20,18 +20,26 @@ class tick_stack::telegraf (
 
   include tick_stack::repo
 
-  class {'tick_stack::telegraf::install':
-    require => Class['tick_stack::repo'],
-    ensure  => $ensure,
-  }
-  -> class {'tick_stack::telegraf::config':
-    conf_path => $conf_path,
-    template  => $template,
-  }
-  ~> class {'tick_stack::telegraf::service':
-    service    => $service,
-    enable     => $enable,
-    hasrestart => $hasrestart,
-    hasstatus  => $hasstatus,
-  }
+  contain tick_stack::telegraf::install
+  contain tick_stack::telegraf::config
+  contain tick_stack::tick_stack::telegraf::service
+
+  Class['tick_stack::telegraf::install']
+  -> Class['tick_stack::telegraf::config']
+  ~> Class['tick_stack::telegraf::service']
+
+  # class {'tick_stack::telegraf::install':
+  #   require => Class['tick_stack::repo'],
+  #   ensure  => $ensure,
+  # }
+  # -> class {'tick_stack::telegraf::config':
+  #   conf_path => $conf_path,
+  #   template  => $template,
+  # }
+  # ~> class {'tick_stack::telegraf::service':
+  #   service    => $service,
+  #   enable     => $enable,
+  #   hasrestart => $hasrestart,
+  #   hasstatus  => $hasstatus,
+  # }
 }

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -1,19 +1,24 @@
 # == Class: tick_stack::telegraf
 #
 class tick_stack::telegraf (
+  # For Install-class
   $ensure      = $tick_stack::telegraf::params::ensure,
 
-  $global_tags = $tick_stack::telegraf::params::global_tags,
-  $agent       = $tick_stack::telegraf::params::agent,
-  $outputs     = $tick_stack::telegraf::params::outputs,
-  $inputs      = $tick_stack::telegraf::params::inputs,
+  # For Config-class
   $conf_path   = $tick_stack::telegraf::params::conf_path,
   $template    = $tick_stack::telegraf::params::template,
 
+  # For Service-class
   $service     = $tick_stack::telegraf::params::service,
   $enable      = $tick_stack::telegraf::params::enable,
   $hasrestart  = $tick_stack::telegraf::params::hasrestart,
   $hasstatus   = $tick_stack::telegraf::params::hasstatus,
+
+  # Specific configuration hashes:
+  Hash $global_tags = $tick_stack::telegraf::params::global_tags,
+  Hash $agent       = $tick_stack::telegraf::params::agent,
+  Hash $outputs     = $tick_stack::telegraf::params::outputs,
+  Hash $inputs      = $tick_stack::telegraf::params::inputs,
 
 
   ) inherits tick_stack::telegraf::params {

--- a/manifests/telegraf/config.pp
+++ b/manifests/telegraf/config.pp
@@ -1,12 +1,16 @@
 # == Class: tick_stack::telegraf::config
 #
-class tick_stack::telegraf::config(
-  $conf_path = $tick_stack::telegraf::params::conf_path,
-  $template  = $tick_stack::telegraf::params::template,
+class tick_stack::telegraf::config {
+  assert_private()
 
-  ) inherits tick_stack::telegraf::params {
+  $conf_path = $tick_stack::telegraf::conf_path
+  $template  = $tick_stack::telegraf::template
+  
   file { $conf_path:
     ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
     content => template($template)
   }
 }

--- a/manifests/telegraf/install.pp
+++ b/manifests/telegraf/install.pp
@@ -1,8 +1,9 @@
 # == Class: tick_stack::telegraf::install
 #
-class tick_stack::telegraf::install (
-  $ensure    = $tick_stack::telegraf::params::ensure,
-  ) inherits tick_stack::telegraf::params {
+class tick_stack::telegraf::install {
+  assert_private()
+
+  $ensure = $tick_stack::telegraf::ensure
 
   package { 'telegraf':
     ensure => $ensure,

--- a/manifests/telegraf/service.pp
+++ b/manifests/telegraf/service.pp
@@ -1,11 +1,13 @@
 # == Class: tick_stack::telegraf::service
 #
-class tick_stack::telegraf::service (
-  $service    = $tick_stack::telegraf::params::service,
-  $enable     = $tick_stack::telegraf::params::enable,
-  $hasrestart = $tick_stack::telegraf::params::hasrestart,
-  $hasstatus  = $tick_stack::telegraf::params::hasstatus,
-  ) inherits tick_stack::telegraf::params {
+class tick_stack::telegraf::service {
+  assert_private()
+  
+  $service    = $tick_stack::telegraf::service
+  $enable     = $tick_stack::telegraf::enable
+  $hasrestart = $tick_stack::telegraf::hasrestart
+  $hasstatus  = $tick_stack::telegraf::hasstatus
+
   service { 'telegraf':
     ensure     => $service,
     enable     => $enable,


### PR DESCRIPTION
Add containment
Change variable scopes in install,config,service classes to `tick_stack::component::variable` instead of `tick_stack::component::params::variable`
Made install,config,service to private